### PR TITLE
Add arg to force comparison and always register/deploy model

### DIFF
--- a/nlp/aml-cli-v2/data-science/src/summarization/compare.py
+++ b/nlp/aml-cli-v2/data-science/src/summarization/compare.py
@@ -38,7 +38,7 @@ def main():
         help="name of reference metric for shipping flag (default: predict_rougeLsum)",
     )
     parser.add_argument(
-        "--force_comparison", type=strtobool, help="set to True to bypass comparison and set --deploy_flag to True"
+        "--force_comparison", type=strtobool, default=False, help="set to True to bypass comparison and set --deploy_flag to True"
     )
     parser.add_argument(
         "--deploy_flag", type=str, help="a deploy flag whether to deploy or not"

--- a/nlp/aml-cli-v2/data-science/src/summarization/compare.py
+++ b/nlp/aml-cli-v2/data-science/src/summarization/compare.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import mlflow
 import json
-
+from distutils.util import strtobool
 
 def main():
     """Main function of the script."""
@@ -38,6 +38,9 @@ def main():
         help="name of reference metric for shipping flag (default: predict_rougeLsum)",
     )
     parser.add_argument(
+        "--force_comparison", type=strtobool, help="set to True to bypass comparison and set --deploy_flag to True"
+    )
+    parser.add_argument(
         "--deploy_flag", type=str, help="a deploy flag whether to deploy or not"
     )
 
@@ -55,16 +58,21 @@ def main():
         candidate_metrics = json.loads(in_file.read())
 
     # should we ship or not?
-    deploy_flag = (
-        candidate_metrics[args.reference_metric]
-        > baseline_metrics[args.reference_metric]
-    )
-    logger.info("baseline_metrics[{}]={}, candidate_metrics[{}]={}, deploy_flag={}".format(
+    if args.force_comparison:
+        deploy_flag = True
+    else:
+        deploy_flag = (
+            candidate_metrics[args.reference_metric]
+            > baseline_metrics[args.reference_metric]
+        )
+
+    logger.info("baseline_metrics[{}]={}, candidate_metrics[{}]={}, deploy_flag={} (force_comparison={})".format(
         args.reference_metric,
         baseline_metrics[args.reference_metric],
         args.reference_metric,
         candidate_metrics[args.reference_metric],
-        deploy_flag
+        deploy_flag,
+        args.force_comparison
     ))
 
     # save deploy_flag as a file

--- a/nlp/aml-cli-v2/mlops/azureml/train/pipeline.yml
+++ b/nlp/aml-cli-v2/mlops/azureml/train/pipeline.yml
@@ -153,7 +153,8 @@ jobs:
       --baseline_metrics ${{inputs.baseline_metrics}} 
       --candidate_metrics ${{inputs.candidate_metrics}} 
       --reference_metric ${{inputs.reference_metric}} 
-      --deploy_flag ${{outputs.deploy_flag}}
+      --deploy_flag ${{outputs.deploy_flag}} 
+      --force_comparison
     environment: azureml:AzureML-sklearn-1.0-ubuntu20.04-py38-cpu@latest
     compute: azureml:cpu-cluster
     inputs:


### PR DESCRIPTION
# PR into Azure/mlops-v2

here's a summary of the issue:

- model deployment in the training pipeline is conditioned to a test comparing the perf of the fine tuned model with the non-fine-tuned model
- in theory the fine-tuned model should win, but we're using a small SKU to allow everyone to run this NLP scenario without specific quota, and we limited the number of data to 1000 and epochs to 5 so that the training pipeline would not take hours
- when running under those conditions, it is likely both models will perform pretty much the same, making comparison between model uncertain
- also the baseline (non-fine-tuned) model is already pretty good in itself, making this comparison uncertain as well

We're proposing to force the comparison by default to switch to an always-deploy scenario, but leave the pipeline as it is so that users can adapt to their needs more easily and see the full extent of the pipeline.

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

- add argument in comparison script to force comparison and force register the model