### PR TITLE
Update bicep-ado-deploy-infra.yml

### DIFF
--- a/infrastructure/bicep/pipelines/bicep-ado-deploy-infra.yml
+++ b/infrastructure/bicep/pipelines/bicep-ado-deploy-infra.yml
@@ -61,7 +61,7 @@ stages :
             steps:
             - checkout: self
             - task: AzureCLI@2
-              displayName: Running Dev Deployment
+              displayName: Running ${{ variables.environment }} Deployment
               inputs:
                 azureSubscription: $(ado_service_connection_rg)
                 scriptType: bash


### PR DESCRIPTION
Update Deployment stage  AzureCLI task to use environment variable for displayName

# PR into Azure/mlops-v2

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Display name for the AzureCLI task was statically set.

fixes #

- Updated displayName to use environment variable 