### PR TITLE
update aml tf module to avoid forcing replacement on rerun (#94)

### DIFF
--- a/infrastructure/terraform/modules/aml-workspace/main.tf
+++ b/infrastructure/terraform/modules/aml-workspace/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_machine_learning_workspace" "mlw" {
   key_vault_id            = var.key_vault_id
   storage_account_id      = var.storage_account_id
   container_registry_id   = var.container_registry_id
+  public_network_access_enabled = true
 
   sku_name = "Basic"
 
@@ -22,7 +23,7 @@ resource "azurerm_machine_learning_compute_cluster" "mlw_compute_cluster" {
   name                          = "cpu-cluster"
   location                      = var.location
   vm_priority                   = "LowPriority"
-  vm_size                       = "Standard_DS3_v2"
+  vm_size                       = "STANDARD_DS3_V2"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.mlw.id
   subnet_resource_id            = var.enable_aml_secure_workspace ? var.subnet_training_id : ""
 
@@ -31,7 +32,7 @@ resource "azurerm_machine_learning_compute_cluster" "mlw_compute_cluster" {
   scale_settings {
     min_node_count                       = 0
     max_node_count                       = 4
-    scale_down_nodes_after_idle_duration = "PT120S" # 120 seconds
+    scale_down_nodes_after_idle_duration = "PT2M" # 120 seconds
   }
 }
 


### PR DESCRIPTION
# PR into Azure/mlops-v2

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- updated parameters in the terraform spec for aml workspace and cluster that currently differ from what the settings are once the first pipeline execution has run, and therefore unnecessarily force replacement of resources.

fixes #94 


When re-running the infra pipeline without making changes to the spec, the `terraform apply` step in the `Deploy AML Workspace` job should report:

```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

As a result it runs faster.
































