### PR TITLE
Upgrade Terraform to 3.32

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,8 +1,8 @@
 terraform {
-  backend "azurerm" {} 
+  backend "azurerm" {}
   required_providers {
     azurerm = {
-      version = "= 2.99.0"
+      version = "= 3.32.0"
     }
   }
 }

--- a/infrastructure/terraform/modules/storage-account/main.tf
+++ b/infrastructure/terraform/modules/storage-account/main.tf
@@ -24,9 +24,7 @@ resource "azurerm_storage_account" "st" {
 # Virtual Network & Firewall configuration
 
 resource "azurerm_storage_account_network_rules" "firewall_rules" {
-  resource_group_name  = var.rg_name
-  storage_account_name = azurerm_storage_account.st.name
-
+  storage_account_id = azurerm_storage_account.st.id
   default_action             = "Allow"
   ip_rules                   = [] # [data.http.ip.body]
   virtual_network_subnet_ids = var.firewall_virtual_network_subnet_ids


### PR DESCRIPTION
# Upgrade Terraform to 3.32

When developing the Terraform locally with Azure CLI version 2.42.0, Terraform can't get the object id of the CLI. 
<img width="507" alt="image" src="https://user-images.githubusercontent.com/8555833/202990188-b64de895-50b6-4349-a486-f03911554c99.png">

This seems to stem from [this issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/16982), therefore I updated my code to the latest AzureRM provider version, and it fixes the issue.

## Checklist

I have:

- [ ] read and followed the contributing guidelines 
- [x] Tested the code by setting all parameters to true and deploying it from scratch

## Changes

- Upgrade Terraform to 3.32
- Update resources to fix errors

fixes #

- Developing with AzureCLI v2.37+
