### PR TITLE
GHA CV pipeline fixes

### DIFF
--- a/cv/aml-cli-v2/mlops/github-actions/deploy-model-training-pipeline.yml
+++ b/cv/aml-cli-v2/mlops/github-actions/deploy-model-training-pipeline.yml
@@ -25,21 +25,35 @@ jobs:
     uses: Azure/mlops-templates/.github/workflows/read-yaml.yml@main-dec31 # TODO - revert to @main
     with:
       file_name: ${{ needs.set-env-branch.outputs.config-file}}
-  create-compute:
+  create-dataprep-compute:
+    needs: [get-config]
+    uses: Azure/mlops-templates/.github/workflows/create-compute.yml@main-dec31
+    with:
+      cluster_name: cpu-cluster
+      size: Standard_DS3_v2
+      min_instances: 0
+      max_instances: 4
+      cluster_tier: low_priority
+      resource_group: ${{ needs.get-config.outputs.resource_group }}
+      workspace_name: ${{ needs.get-config.outputs.aml_workspace }}
+    secrets:
+      creds: ${{secrets.AZURE_CREDENTIALS}}
+  create-training-compute:
     needs: get-config
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-create-compute.yml@main-dec31 # TODO - revert to @main
+    uses: Azure/mlops-templates/.github/workflows/create-compute.yml@main-dec31 # TODO - revert to @main
     with:
       cluster_name: gpu-cluster
       size: Standard_NC6
       min_instances: 0
       max_instances: 1
+      cluster_tier: low_priority
       resource_group: ${{ needs.get-config.outputs.resource_group }}
       workspace_name: ${{ needs.get-config.outputs.aml_workspace }}
     secrets:
       creds: ${{secrets.AZURE_CREDENTIALS}}
   register-environment:
-    needs: [get-config, create-compute]
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-register-environment.yml@main-dec31 # TODO - revert to @main
+    needs: [get-config, create-dataprep-compute, create-training-compute]
+    uses: Azure/mlops-templates/.github/workflows/register-environment.yml@main-dec31 # TODO - revert to @main
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}
       workspace_name: ${{ needs.get-config.outputs.aml_workspace }}
@@ -48,7 +62,7 @@ jobs:
       creds: ${{secrets.AZURE_CREDENTIALS}}
   register-dataset:
     needs: [get-config, register-environment]
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-register-dataset.yml@main-dec31 # TODO - revert to @main
+    uses: Azure/mlops-templates/.github/workflows/register-dataset.yml@main-dec31 # TODO - revert to @main
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}
       workspace_name: ${{ needs.get-config.outputs.aml_workspace }}
@@ -57,9 +71,16 @@ jobs:
       name: stanford_dogs
     secrets:
       creds: ${{secrets.AZURE_CREDENTIALS}}
-  run-pipeline:
-    needs: [get-config, register-dataset]
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-run-pipeline.yml@main-dec31 # TODO - revert to @main
+  run-model-training-pipeline:
+    needs:
+      [
+        get-config,
+        create-dataprep-compute,
+        create-training-compute,
+        register-environment,
+        register-dataset,
+      ]
+    uses: Azure/mlops-templates/.github/workflows/run-pipeline.yml@main-dec31 # TODO - revert to @main
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}
       workspace_name: ${{ needs.get-config.outputs.aml_workspace }}

--- a/cv/aml-cli-v2/mlops/github-actions/deploy-online-endpoint-pipeline.yml
+++ b/cv/aml-cli-v2/mlops/github-actions/deploy-online-endpoint-pipeline.yml
@@ -27,7 +27,7 @@ jobs:
       file_name: ${{ needs.set-env-branch.outputs.config-file}}
   create-endpoint:
     needs: get-config
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-create-endpoint.yml@main-dec31 # TODO - revert to @main
+    uses: Azure/mlops-templates/.github/workflows/create-endpoint.yml@main-dec31 # TODO - revert to @main
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}
       workspace_name: ${{ needs.get-config.outputs.aml_workspace }}
@@ -37,7 +37,7 @@ jobs:
     secrets:
       creds: ${{secrets.AZURE_CREDENTIALS}}
   create-deployment:
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-create-deployment.yml@main-dec31 # TODO - revert to @main
+    uses: Azure/mlops-templates/.github/workflows/create-deployment.yml@main-dec31 # TODO - revert to @main
     needs: [get-config, create-endpoint]
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}
@@ -49,7 +49,7 @@ jobs:
     secrets:
       creds: ${{secrets.AZURE_CREDENTIALS}}
   allocate-traffic:
-    uses: Azure/mlops-templates/.github/workflows/cli-v2-allocate-traffic.yml@main-dec31 # TODO - revert to @main
+    uses: Azure/mlops-templates/.github/workflows/allocate-traffic.yml@main-dec31 # TODO - revert to @main
     needs: [get-config, create-deployment]
     with:
       resource_group: ${{ needs.get-config.outputs.resource_group }}


### PR DESCRIPTION
* Removed cli-v2- from resource creation gha action filenames for both training and endpoint deployment
* Added create-dataprep-compute (cpu) step and renamed create-compute to create-training-compute (gpu) to create two clusters. CV training pipeline uses both.
* Added missing cluster-tier to create-compute.