### PR TITLE
fix: update vmImage from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/classical/aml-cli-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
+++ b/classical/aml-cli-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/classical/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
+++ b/classical/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/python-sdk-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
+++ b/classical/python-sdk-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
@@ -18,7 +18,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/python-sdk-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/classical/python-sdk-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/python-sdk-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
+++ b/classical/python-sdk-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
@@ -18,7 +18,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
+++ b/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-batch-endpoint-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
+++ b/classical/rai-aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/cv/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/cv/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/cv/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
+++ b/cv/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
@@ -18,7 +18,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/cv/python-sdk-v1/config-aml.yml
+++ b/cv/python-sdk-v1/config-aml.yml
@@ -1,6 +1,6 @@
 variables:
 
-  ap_vm_image: ubuntu-20.04
+  ap_vm_image: ubuntu-latest
 
 ## Training pipeline settings
 

--- a/infrastructure/terraform/devops-pipelines/tf-ado-deploy-infra.yml
+++ b/infrastructure/terraform/devops-pipelines/tf-ado-deploy-infra.yml
@@ -14,7 +14,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/nlp/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/nlp/aml-cli-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/nlp/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
+++ b/nlp/aml-cli-v2/mlops/devops-pipelines/deploy-online-endpoint-pipeline.yml
@@ -18,7 +18,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:

--- a/nlp/python-sdk-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
+++ b/nlp/python-sdk-v2/mlops/devops-pipelines/deploy-model-training-pipeline.yml
@@ -16,7 +16,7 @@ variables:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 
 resources:
   repositories:


### PR DESCRIPTION
ubuntu-20.04 was retired by Microsoft from the hosted Azure Pipelines pool, causing 'No image label found to route agent pool Azure Pipelines' errors at the Deploy Azure Machine Learning Model Training Pipeline stage of the accelerator end-to-end flow.

Updates 16 pipeline configurations across all architecture patterns (classical, cv, nlp) and tooling variants (aml-cli-v2, python-sdk-v2, rai-aml-cli-v2, terraform).

Reported by Vicky Arpatzoglou via accelerator feedback.

# PR into Azure/mlops-project-template

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

-

fixes #
