### PR TITLE
feat(tier-2): networking, phased Bicep, and identity-based auth

### DIFF
--- a/.github/workflows/bicep-gha-deploy-infra.yml
+++ b/.github/workflows/bicep-gha-deploy-infra.yml
@@ -1,0 +1,284 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: Bicep - Deploy Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform (deploy or destroy)'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - destroy
+      wait_for_destroy:
+        description: 'Wait for resource group deletion to complete'
+        required: false
+        default: true
+        type: boolean
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/bicep/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/bicep/**'
+
+env:
+  config_env: "none"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  set-env-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      config-file: ${{ steps.set-output-defaults.outputs.config-file }}
+      environment: ${{ steps.set-output-defaults.outputs.environment }}
+    steps:
+      - id: set-prod-branch
+        name: set-prod-branch
+        if: ${{ github.ref == 'refs/heads/main'}}
+        run: |
+          echo "config_env=config-infra-prod.yml" >> $GITHUB_ENV
+          echo "env_name=prod" >> $GITHUB_ENV
+      - id: set-dev-branch
+        name: setdevbranch
+        if: ${{ github.ref != 'refs/heads/main'}}
+        run: |
+          echo "config_env=config-infra-dev.yml" >> $GITHUB_ENV
+          echo "env_name=dev" >> $GITHUB_ENV
+      - id: set-output-defaults
+        name: set-output-defaults
+        run: |
+          echo "config-file=$config_env" >> $GITHUB_OUTPUT
+          echo "environment=$env_name" >> $GITHUB_OUTPUT
+
+  get-config:
+    needs: set-env-branch
+    permissions:
+      contents: read
+    uses: Azure/mlops-templates/.github/workflows/read-yaml.yml@main
+    with:
+      file_name: ${{ needs.set-env-branch.outputs.config-file}}
+
+  lint:
+    name: Lint Bicep Code
+    needs: [get-config, set-env-branch]
+    runs-on: ubuntu-latest
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Bicep CLI
+        run: |
+          # Install Bicep CLI directly (no Azure login needed for linting)
+          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep /usr/local/bin/bicep
+          bicep --version
+
+      - name: Lint Bicep
+        run: |
+          bicep build $BICEP_DIR/$BICEP_FILE
+
+  validate:
+    name: Validate Bicep Deployment
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch, lint]
+    if: github.event_name != 'pull_request'
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    outputs:
+      sp_object_id: ${{ steps.get_sp_info.outputs.sp_object_id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Service Principal Object ID
+        id: get_sp_info
+        run: |
+          # Get the SP object ID from the client ID
+          SP_OBJECT_ID=$(az ad sp show --id ${{ secrets.AZURE_CLIENT_ID }} --query id -o tsv)
+          
+          echo "Service Principal Client ID: ${{ secrets.AZURE_CLIENT_ID }}"
+          echo "Service Principal Object ID: $SP_OBJECT_ID"
+          echo "sp_object_id=$SP_OBJECT_ID" >> $GITHUB_OUTPUT
+
+      - name: Generate Parameters File
+        run: |
+          cat > $BICEP_DIR/parameters.json << EOF
+          {
+            "\$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "prefix": { "value": "${{ needs.get-config.outputs.namespace }}" },
+              "postfix": { "value": "${{ needs.get-config.outputs.postfix }}" },
+              "env": { "value": "${{ needs.get-config.outputs.environment }}" },
+              "location": { "value": "${{ needs.get-config.outputs.location }}" },
+              "adoServicePrincipalId": { "value": "${{ steps.get_sp_info.outputs.sp_object_id }}" },
+              "amlComputeSku": { "value": "${{ needs.get-config.outputs.aml_compute_sku }}" },
+              "enableVNet": { "value": ${{ needs.get-config.outputs.enable_vnet }} },
+              "vnetAddressPrefix": { "value": "${{ needs.get-config.outputs.vnet_address_prefix }}" },
+              "defaultSubnetPrefix": { "value": "${{ needs.get-config.outputs.default_subnet_prefix }}" },
+              "computeSubnetPrefix": { "value": "${{ needs.get-config.outputs.compute_subnet_prefix }}" },
+              "peSubnetPrefix": { "value": "${{ needs.get-config.outputs.pe_subnet_prefix }}" },
+              "enableContainerRegistry": { "value": ${{ needs.get-config.outputs.enable_container_registry }} },
+              "tagCostCenter": { "value": "${{ needs.get-config.outputs.tag_cost_center }}" },
+              "tagManagedBy": { "value": "${{ needs.get-config.outputs.tag_managed_by }}" }
+            }
+          }
+          EOF
+          echo "Generated parameters.json:"
+          cat $BICEP_DIR/parameters.json
+
+      - name: Validate Bicep Deployment
+        run: |
+          az deployment sub validate \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --location ${{ needs.get-config.outputs.location }} \
+            --template-file $BICEP_DIR/$BICEP_FILE \
+            --parameters @$BICEP_DIR/parameters.json
+
+  deploy:
+    name: Deploy Infrastructure
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch, lint, validate]
+    if: github.event_name != 'pull_request' && github.event.inputs.action != 'destroy'
+    environment: ${{ needs.set-env-branch.outputs.environment }}
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Service Principal Object ID
+        id: get_sp_info
+        run: |
+          SP_OBJECT_ID=$(az ad sp show --id ${{ secrets.AZURE_CLIENT_ID }} --query id -o tsv)
+          
+          echo "Service Principal Client ID: ${{ secrets.AZURE_CLIENT_ID }}"
+          echo "Service Principal Object ID: $SP_OBJECT_ID"
+          echo "sp_object_id=$SP_OBJECT_ID" >> $GITHUB_OUTPUT
+
+      - name: Generate Parameters File
+        run: |
+          cat > $BICEP_DIR/parameters.json << EOF
+          {
+            "\$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "prefix": { "value": "${{ needs.get-config.outputs.namespace }}" },
+              "postfix": { "value": "${{ needs.get-config.outputs.postfix }}" },
+              "env": { "value": "${{ needs.get-config.outputs.environment }}" },
+              "location": { "value": "${{ needs.get-config.outputs.location }}" },
+              "adoServicePrincipalId": { "value": "${{ steps.get_sp_info.outputs.sp_object_id }}" },
+              "amlComputeSku": { "value": "${{ needs.get-config.outputs.aml_compute_sku }}" },
+              "enableVNet": { "value": ${{ needs.get-config.outputs.enable_vnet }} },
+              "vnetAddressPrefix": { "value": "${{ needs.get-config.outputs.vnet_address_prefix }}" },
+              "defaultSubnetPrefix": { "value": "${{ needs.get-config.outputs.default_subnet_prefix }}" },
+              "computeSubnetPrefix": { "value": "${{ needs.get-config.outputs.compute_subnet_prefix }}" },
+              "peSubnetPrefix": { "value": "${{ needs.get-config.outputs.pe_subnet_prefix }}" },
+              "enableContainerRegistry": { "value": ${{ needs.get-config.outputs.enable_container_registry }} },
+              "tagCostCenter": { "value": "${{ needs.get-config.outputs.tag_cost_center }}" },
+              "tagManagedBy": { "value": "${{ needs.get-config.outputs.tag_managed_by }}" }
+            }
+          }
+          EOF
+          echo "Generated parameters.json:"
+          cat $BICEP_DIR/parameters.json
+
+      - name: Deploy Bicep Template
+        run: |
+          echo "Deploying to ${{ needs.set-env-branch.outputs.environment }} environment..."
+          
+          az deployment sub create \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --location ${{ needs.get-config.outputs.location }} \
+            --template-file $BICEP_DIR/$BICEP_FILE \
+            --parameters @$BICEP_DIR/parameters.json
+
+      - name: Output Deployment Results
+        run: |
+          echo "Deployment completed successfully!"
+          az deployment sub show \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --query properties.outputs
+
+  destroy:
+    name: Destroy Infrastructure
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch]
+    if: github.event.inputs.action == 'destroy'
+    environment: ${{ needs.set-env-branch.outputs.environment }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Delete Resource Group
+        run: |
+          echo "Destroying ${{ needs.set-env-branch.outputs.environment }} environment..."
+          
+          RG_NAME="rg-${{ needs.get-config.outputs.namespace }}-${{ needs.get-config.outputs.postfix }}${{ needs.get-config.outputs.environment }}"
+          MLW_NAME="mlw-${{ needs.get-config.outputs.namespace }}-${{ needs.get-config.outputs.postfix }}${{ needs.get-config.outputs.environment }}"
+          
+          echo "Deleting resource group: $RG_NAME"
+          
+          # Check if we should wait for deletion to complete
+          if [ "${{ github.event.inputs.wait_for_destroy }}" == "true" ]; then
+            echo "Waiting for resource group deletion to complete..."
+            az group delete --name $RG_NAME --yes
+            echo "Resource group $RG_NAME has been deleted!"
+            
+            # Purge soft-deleted ML Workspace
+            echo "Purging soft-deleted ML Workspace..."
+            az ml workspace delete --name $MLW_NAME --resource-group $RG_NAME --permanently-delete --yes 2>/dev/null || true
+            
+            # Purge any soft-deleted Key Vaults to allow redeployment
+            echo "Purging soft-deleted Key Vaults..."
+            DELETED_KVS=$(az keyvault list-deleted --query "[?contains(properties.vaultId, '$RG_NAME')].name" -o tsv 2>/dev/null || true)
+            for KV_NAME in $DELETED_KVS; do
+              echo "Purging Key Vault: $KV_NAME"
+              az keyvault purge --name $KV_NAME --location ${{ needs.get-config.outputs.location }} --no-wait || true
+            done
+            echo "Cleanup complete!"
+          else
+            az group delete --name $RG_NAME --yes --no-wait
+            echo "Resource group deletion initiated (async)!"
+          fi

--- a/config-infra-dev.yml
+++ b/config-infra-dev.yml
@@ -13,6 +13,13 @@ variables:
   enable_aml_computecluster: true
   enable_monitoring: false
   enable_container_registry: true
+  enable_vnet: false
+
+  # VNet settings (only used when enable_vnet: true)
+  vnet_address_prefix: '10.0.0.0/16'
+  default_subnet_prefix: '10.0.0.0/24'
+  compute_subnet_prefix: '10.0.1.0/24'
+  pe_subnet_prefix: '10.0.2.0/24'
   
   # Tags
   tag_cost_center: ''

--- a/config-infra-prod.yml
+++ b/config-infra-prod.yml
@@ -13,6 +13,13 @@ variables:
   enable_aml_computecluster: true
   enable_monitoring: false
   enable_container_registry: true
+  enable_vnet: false
+
+  # VNet settings (only used when enable_vnet: true)
+  vnet_address_prefix: '10.0.0.0/16'
+  default_subnet_prefix: '10.0.0.0/24'
+  compute_subnet_prefix: '10.0.1.0/24'
+  pe_subnet_prefix: '10.0.2.0/24'
   
   # Tags
   tag_cost_center: ''

--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -9,10 +9,24 @@ param env string
 param enableMonitoring bool = true
 param enableContainerRegistry bool = true
 param enableComputeCluster bool = true
+param enableVNet bool = false
 
 // Key Vault settings
 param kvEnablePurgeProtection bool = false
 param kvSoftDeleteRetentionDays int = 7
+
+// VNet settings (only used when enableVNet = true)
+param vnetAddressPrefix string = '10.0.0.0/16'
+param defaultSubnetPrefix string = '10.0.0.0/24'
+param computeSubnetPrefix string = '10.0.1.0/24'
+param peSubnetPrefix string = '10.0.2.0/24'
+
+// Compute cluster VM SKU
+param amlComputeSku string = 'Standard_DS3_v2'
+
+// Object ID of the ADO service connection's service principal. When set, the
+// pipeline SP is granted the data-plane roles it needs to run AML jobs.
+param adoServicePrincipalId string = ''
 
 // Tag parameters
 param tagCostCenter string = ''
@@ -31,12 +45,55 @@ param tags object = {
 var baseName  = '${prefix}-${postfix}${env}'
 var resourceGroupName = 'rg-${baseName}'
 
+// ============================================================
+// Phase 1 — Foundation: Resource Group, Managed Identity, VNet
+// ============================================================
+
 resource rg 'Microsoft.Resources/resourceGroups@2020-06-01' = {
   name: resourceGroupName
   location: location
-
   tags: tags
 }
+
+// Managed Identity for AML workspace
+module mi './modules/managed_identity.bicep' = {
+  name: 'mi'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    managedIdentityName: 'id-${baseName}'
+    tags: tags
+  }
+}
+
+// VNet — conditional on enableVNet
+module vnet './modules/vnet.bicep' = if (enableVNet) {
+  name: 'vnet'
+  scope: resourceGroup(rg.name)
+  params: {
+    baseName: baseName
+    location: location
+    tags: tags
+    vnetAddressPrefix: vnetAddressPrefix
+    defaultSubnetPrefix: defaultSubnetPrefix
+    computeSubnetPrefix: computeSubnetPrefix
+    privateEndpointSubnetPrefix: peSubnetPrefix
+  }
+}
+
+// Private DNS Zones — conditional on enableVNet
+module dnsZones './modules/private_dns_zones.bicep' = if (enableVNet) {
+  name: 'dnsZones'
+  scope: resourceGroup(rg.name)
+  params: {
+    tags: tags
+    vnetId: enableVNet ? vnet!.outputs.vnetId : ''
+  }
+}
+
+// ============================================================
+// Phase 2 — Core Infrastructure: Storage, KV, ACR, App Insights
+// ============================================================
 
 // Storage Account
 module st './modules/storage_account.bicep' = {
@@ -46,6 +103,11 @@ module st './modules/storage_account.bicep' = {
     baseName: '${uniqueString(rg.id)}${env}'
     location: location
     tags: tags
+    enableNetworkIsolation: enableVNet
+    allowedSubnetIds: enableVNet ? [
+      vnet!.outputs.defaultSubnetId
+      vnet!.outputs.computeSubnetId
+    ] : []
   }
 }
 
@@ -59,6 +121,11 @@ module kv './modules/key_vault.bicep' = {
     tags: tags
     enablePurgeProtection: kvEnablePurgeProtection
     softDeleteRetentionDays: kvSoftDeleteRetentionDays
+    enableNetworkIsolation: enableVNet
+    allowedSubnetIds: enableVNet ? [
+      vnet!.outputs.defaultSubnetId
+      vnet!.outputs.computeSubnetId
+    ] : []
   }
 }
 
@@ -81,10 +148,75 @@ module cr './modules/container_registry.bicep' = if (enableContainerRegistry) {
     baseName: '${uniqueString(rg.id)}${env}'
     location: location
     tags: tags
+    enableNetworkIsolation: enableVNet
   }
 }
 
-// AML workspace
+// Private Endpoints — conditional on enableVNet
+module peStorage './modules/private_endpoint.bicep' = if (enableVNet) {
+  name: 'pe-storage'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    tags: tags
+    privateEndpointName: 'pe-st-${baseName}'
+    targetResourceId: st.outputs.stoacctOut
+    groupId: 'blob'
+    subnetId: enableVNet ? vnet!.outputs.privateEndpointSubnetId : ''
+    privateDnsZoneId: enableVNet ? dnsZones!.outputs.blobDnsZoneId : ''
+  }
+}
+
+// Storage file private endpoint — AML uses the file share (workspacefilestore)
+// in addition to blob, so it also needs a PE or the file datastore is
+// unreachable once public network access is denied.
+module peStorageFile './modules/private_endpoint.bicep' = if (enableVNet) {
+  name: 'pe-storage-file'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    tags: tags
+    privateEndpointName: 'pe-stfile-${baseName}'
+    targetResourceId: st.outputs.stoacctOut
+    groupId: 'file'
+    subnetId: enableVNet ? vnet!.outputs.privateEndpointSubnetId : ''
+    privateDnsZoneId: enableVNet ? dnsZones!.outputs.fileDnsZoneId : ''
+  }
+}
+
+module peKeyVault './modules/private_endpoint.bicep' = if (enableVNet) {
+  name: 'pe-kv'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    tags: tags
+    privateEndpointName: 'pe-kv-${baseName}'
+    targetResourceId: kv.outputs.kvOut
+    groupId: 'vault'
+    subnetId: enableVNet ? vnet!.outputs.privateEndpointSubnetId : ''
+    privateDnsZoneId: enableVNet ? dnsZones!.outputs.kvDnsZoneId : ''
+  }
+}
+
+module peCr './modules/private_endpoint.bicep' = if (enableVNet && enableContainerRegistry) {
+  name: 'pe-cr'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    tags: tags
+    privateEndpointName: 'pe-cr-${baseName}'
+    targetResourceId: enableContainerRegistry ? cr!.outputs.crOut : ''
+    groupId: 'registry'
+    subnetId: enableVNet ? vnet!.outputs.privateEndpointSubnetId : ''
+    privateDnsZoneId: enableVNet ? dnsZones!.outputs.acrDnsZoneId : ''
+  }
+}
+
+// ============================================================
+// Phase 3 — AI Platform: AML Workspace, Compute, RBAC
+// ============================================================
+
+// AML workspace with user-assigned identity and RBAC
 module mlw './modules/aml_workspace.bicep' = {
   name: 'mlw'
   scope: resourceGroup(rg.name)
@@ -95,7 +227,26 @@ module mlw './modules/aml_workspace.bicep' = {
     kvid: kv.outputs.kvOut
     appinsightid: enableMonitoring ? appi!.outputs.appinsightOut : ''
     crid: enableContainerRegistry ? cr!.outputs.crOut : ''
+    managedIdentityId: mi.outputs.managedIdentityId
+    managedIdentityPrincipalId: mi.outputs.managedIdentityPrincipalId
+    adoServicePrincipalId: adoServicePrincipalId
+    enableNetworkIsolation: enableVNet
     tags: tags
+  }
+}
+
+// AML workspace private endpoint
+module peMlw './modules/private_endpoint.bicep' = if (enableVNet) {
+  name: 'pe-mlw'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+    tags: tags
+    privateEndpointName: 'pe-mlw-${baseName}'
+    targetResourceId: mlw.outputs.amlsId
+    groupId: 'amlworkspace'
+    subnetId: enableVNet ? vnet!.outputs.privateEndpointSubnetId : ''
+    privateDnsZoneId: enableVNet ? dnsZones!.outputs.amlDnsZoneId : ''
   }
 }
 
@@ -106,5 +257,8 @@ module mlwcc './modules/aml_computecluster.bicep' = if (enableComputeCluster) {
   params: {
     location: location
     workspaceName: mlw.outputs.amlsName
+    vmSku: amlComputeSku
+    managedIdentityId: mi.outputs.managedIdentityId
+    subnetId: enableVNet ? vnet!.outputs.computeSubnetId : ''
   }
 }

--- a/infrastructure/bicep/modules/aml_computecluster.bicep
+++ b/infrastructure/bicep/modules/aml_computecluster.bicep
@@ -1,20 +1,31 @@
 param location string
 param computeClusterName string = 'cpu-cluster'
 param workspaceName string
+param vmSku string = 'STANDARD_D16S_V3'
+param managedIdentityId string
+param subnetId string = ''
 
-resource amlci 'Microsoft.MachineLearningServices/workspaces/computes@2020-09-01-preview' = {
+resource amlci 'Microsoft.MachineLearningServices/workspaces/computes@2025-09-01' = {
   name: '${workspaceName}/${computeClusterName}'
   location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
   properties: {
     computeType: 'AmlCompute'
     properties: {
-      vmSize: 'Standard_DS3_v2'
-      subnet: json('null')
+      vmSize: vmSku
       osType: 'Linux'
       scaleSettings: {
         maxNodeCount: 4
         minNodeCount: 0
       }
+      subnet: !empty(subnetId) ? {
+        id: subnetId
+      } : null
     }
   }
 }

--- a/infrastructure/bicep/modules/aml_workspace.bicep
+++ b/infrastructure/bicep/modules/aml_workspace.bicep
@@ -5,28 +5,45 @@ param kvid string
 param appinsightid string
 param crid string
 param tags object
+param managedIdentityId string
+param managedIdentityPrincipalId string
+param adoServicePrincipalId string = ''
+param enableNetworkIsolation bool = false
 
-// Optional resource handling — main.bicep may pass empty strings when
-// enableMonitoring or enableContainerRegistry are false.
+// Extract resource IDs for RBAC assignments
+var storageAccountName = split(stoacctid, '/')[8]
+var keyVaultName = split(kvid, '/')[8]
 var hasContainerRegistry = !empty(crid)
+var containerRegistryName = hasContainerRegistry ? split(crid, '/')[8] : 'none'
 var hasAppInsights = !empty(appinsightid)
 
-// AML workspace
-resource amls 'Microsoft.MachineLearningServices/workspaces@2020-09-01-preview' = {
+// AML workspace with user-assigned managed identity
+resource amls 'Microsoft.MachineLearningServices/workspaces@2024-04-01' = {
   name: 'mlw-${baseName}'
   location: location
   identity: {
-    type: 'SystemAssigned'
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
   }
   sku: {
-    tier: 'basic'
-    name: 'basic'
+    tier: 'Basic'
+    name: 'Basic'
   }
   properties: {
     storageAccount: stoacctid
     keyVault: kvid
     applicationInsights: hasAppInsights ? appinsightid : null
     containerRegistry: hasContainerRegistry ? crid : null
+    primaryUserAssignedIdentity: managedIdentityId
+    // systemDatastoresAuthMode is a valid runtime property (identity-based datastore
+    // access); Bicep's type definitions for this API version lag behind the REST API.
+    #disable-next-line BCP037
+    systemDatastoresAuthMode: 'identity'
+    publicNetworkAccess: enableNetworkIsolation ? 'Disabled' : 'Enabled'
+    imageBuildCompute: hasContainerRegistry ? 'cpu-cluster' : null
+    v1LegacyMode: false
     encryption: {
       status: 'Disabled'
       keyVaultProperties: {
@@ -39,4 +56,97 @@ resource amls 'Microsoft.MachineLearningServices/workspaces@2020-09-01-preview' 
   tags: tags
 }
 
+// Get existing storage account for RBAC assignments
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
+  name: storageAccountName
+}
+
+// Get existing key vault for RBAC assignments
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' existing = {
+  name: keyVaultName
+}
+
+// Get existing container registry for RBAC assignments (only when CR is deployed)
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2025-11-01' existing = if (hasContainerRegistry) {
+  name: containerRegistryName
+}
+
+// RBAC: Workspace MSI -> Storage Blob Data Contributor
+resource workspaceMsiStorageBlobContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, managedIdentityPrincipalId, 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe') // Storage Blob Data Contributor
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Workspace MSI -> Storage Account Contributor
+resource workspaceMsiStorageAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, managedIdentityPrincipalId, '17d1049b-9a84-46fb-8f53-869881c3d3ab')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab') // Storage Account Contributor
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Workspace MSI -> Key Vault Administrator
+resource workspaceMsiKeyVaultAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, managedIdentityPrincipalId, '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483') // Key Vault Administrator
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Workspace MSI -> ACR Pull (only when container registry is deployed)
+resource workspaceMsiAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (hasContainerRegistry) {
+  name: guid(containerRegistry.id, managedIdentityPrincipalId, '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  scope: containerRegistry
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d') // AcrPull
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: ADO Service Principal -> Storage Blob Data Reader (for data registration)
+resource adoSpStorageBlobReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(adoServicePrincipalId)) {
+  name: guid(storageAccount.id, adoServicePrincipalId, '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1') // Storage Blob Data Reader
+    principalId: adoServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: ADO Service Principal -> Storage Blob Data Contributor (for data registration)
+resource adoSpStorageBlobContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(adoServicePrincipalId)) {
+  name: guid(storageAccount.id, adoServicePrincipalId, 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe') // Storage Blob Data Contributor
+    principalId: adoServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: ADO Service Principal -> AzureML Workspace Contributor (for model registration)
+resource adoSpWorkspaceContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(adoServicePrincipalId)) {
+  name: guid(amls.id, adoServicePrincipalId, 'f6c7c914-8db3-469d-8ca1-694a8f32e121')
+  scope: amls
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f6c7c914-8db3-469d-8ca1-694a8f32e121') // AzureML Compute Operator
+    principalId: adoServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 output amlsName string = amls.name
+output amlsId string = amls.id

--- a/infrastructure/bicep/modules/container_registry.bicep
+++ b/infrastructure/bicep/modules/container_registry.bicep
@@ -1,19 +1,26 @@
 param baseName string
 param location string
 param tags object
+param enableNetworkIsolation bool = false
+
+// Premium SKU required for private endpoints; Standard when public
+var skuName = enableNetworkIsolation ? 'Premium' : 'Standard'
 
 resource cr 'Microsoft.ContainerRegistry/registries@2020-11-01-preview' = {
   name: 'cr${baseName}'
   location: location
   sku: {
-    name: 'Standard'
+    name: skuName
   }
 
   properties: {
     adminUserEnabled: false
+    publicNetworkAccess: enableNetworkIsolation ? 'Disabled' : 'Enabled'
+    networkRuleBypassOptions: enableNetworkIsolation ? 'AzureServices' : 'None'
   }
 
   tags: tags
 }
 
 output crOut string = cr.id
+output crName string = cr.name

--- a/infrastructure/bicep/modules/key_vault.bicep
+++ b/infrastructure/bicep/modules/key_vault.bicep
@@ -3,6 +3,13 @@ param location string
 param tags object
 param enablePurgeProtection bool = false
 param softDeleteRetentionDays int = 7
+param enableNetworkIsolation bool = false
+param allowedSubnetIds array = []
+
+// Build VNet rules array for network ACLs
+var virtualNetworkRules = [for subnetId in allowedSubnetIds: {
+  id: subnetId
+}]
 
 // Key Vault — RBAC-authorized, idempotent with soft-delete handling
 // Note: enablePurgeProtection cannot be disabled once enabled
@@ -19,9 +26,17 @@ resource kv 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
     enableSoftDelete: true
     softDeleteRetentionInDays: softDeleteRetentionDays
     enablePurgeProtection: enablePurgeProtection ? true : null
+    networkAcls: enableNetworkIsolation ? {
+      defaultAction: 'Deny'
+      bypass: 'AzureServices'
+      virtualNetworkRules: virtualNetworkRules
+    } : {
+      defaultAction: 'Allow'
+    }
   }
 
   tags: tags
 }
 
 output kvOut string = kv.id
+output kvName string = kv.name

--- a/infrastructure/bicep/modules/managed_identity.bicep
+++ b/infrastructure/bicep/modules/managed_identity.bicep
@@ -1,0 +1,22 @@
+// Creates a user-assigned managed identity for Azure Machine Learning workspace
+@description('Azure region of the deployment')
+param location string
+
+@description('Tags to add to the resources')
+param tags object
+
+@description('Name of the managed identity')
+param managedIdentityName string
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: managedIdentityName
+  location: location
+  properties: {
+    isolationScope: 'None'
+  }
+  tags: tags
+}
+
+output managedIdentityId string = managedIdentity.id
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId
+output managedIdentityClientId string = managedIdentity.properties.clientId

--- a/infrastructure/bicep/modules/private_dns_zones.bicep
+++ b/infrastructure/bicep/modules/private_dns_zones.bicep
@@ -1,0 +1,43 @@
+// Private DNS Zones for private link resolution
+param tags object
+param vnetId string
+
+// Use environment() suffixes for cloud-agnostic DNS zone names
+var storageSuffix = environment().suffixes.storage  // e.g. core.windows.net
+var dnsZones = [
+  'privatelink.blob.${storageSuffix}'
+  'privatelink.vaultcore.azure.net'
+  'privatelink.azurecr.io'
+  'privatelink.api.azureml.ms'
+  'privatelink.notebooks.azure.net'
+  'privatelink.file.${storageSuffix}'
+  'privatelink.dfs.${storageSuffix}'
+]
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = [for zone in dnsZones: {
+  name: zone
+  location: 'global'
+  tags: tags
+}]
+
+// Link each DNS zone to the VNet
+resource vnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = [for (zone, i) in dnsZones: {
+  name: 'link-${uniqueString(vnetId)}'
+  parent: privateDnsZone[i]
+  location: 'global'
+  properties: {
+    virtualNetwork: {
+      id: vnetId
+    }
+    registrationEnabled: false
+  }
+  tags: tags
+}]
+
+output blobDnsZoneId string = privateDnsZone[0].id
+output kvDnsZoneId string = privateDnsZone[1].id
+output acrDnsZoneId string = privateDnsZone[2].id
+output amlDnsZoneId string = privateDnsZone[3].id
+output notebookDnsZoneId string = privateDnsZone[4].id
+output fileDnsZoneId string = privateDnsZone[5].id
+output dfsDnsZoneId string = privateDnsZone[6].id

--- a/infrastructure/bicep/modules/private_endpoint.bicep
+++ b/infrastructure/bicep/modules/private_endpoint.bicep
@@ -1,0 +1,48 @@
+// Generic private endpoint module — reusable for Storage, KV, ACR, AML Workspace
+param location string
+param tags object
+param privateEndpointName string
+param targetResourceId string
+param groupId string  // e.g. 'blob', 'vault', 'registry', 'amlworkspace'
+param subnetId string
+param privateDnsZoneId string = ''
+
+resource pe 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+  name: privateEndpointName
+  location: location
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: targetResourceId
+          groupIds: [
+            groupId
+          ]
+        }
+      }
+    ]
+  }
+  tags: tags
+}
+
+// DNS zone group — links PE to private DNS zone for automatic DNS resolution
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = if (!empty(privateDnsZoneId)) {
+  name: 'default'
+  parent: pe
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+output privateEndpointId string = pe.id

--- a/infrastructure/bicep/modules/seeding_keyvault.bicep
+++ b/infrastructure/bicep/modules/seeding_keyvault.bicep
@@ -1,0 +1,36 @@
+// Seeding Key Vault — pre-existing KV that holds SP credentials and secrets
+// Pipeline fetches creds at runtime instead of relying on service connection alone
+// Supports firewall with temporary build agent IP whitelisting
+param baseName string
+param location string
+param tags object
+param enableNetworkIsolation bool = false
+
+resource seedKv 'Microsoft.KeyVault/vaults@2025-05-01' = {
+  name: 'kvseed-${baseName}'
+  location: location
+  properties: {
+    tenantId: subscription().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
+    networkAcls: enableNetworkIsolation ? {
+      defaultAction: 'Deny'
+      bypass: 'AzureServices'
+      // IP rules are managed dynamically by the pipeline (whitelist/cleanup pattern)
+      ipRules: []
+      virtualNetworkRules: []
+    } : {
+      defaultAction: 'Allow'
+    }
+  }
+  tags: tags
+}
+
+output seedKvName string = seedKv.name
+output seedKvId string = seedKv.id

--- a/infrastructure/bicep/modules/storage_account.bicep
+++ b/infrastructure/bicep/modules/storage_account.bicep
@@ -1,9 +1,17 @@
 param baseName string
 param location string
 param tags object
+param enableNetworkIsolation bool = false
+param allowedSubnetIds array = []
+
+// Build VNet rules array for network ACLs
+var virtualNetworkRules = [for subnetId in allowedSubnetIds: {
+  id: subnetId
+  action: 'Allow'
+}]
 
 // Storage Account
-resource stoacct 'Microsoft.Storage/storageAccounts@2019-04-01' = {
+resource stoacct 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: 'st${baseName}'
   location: location
   sku: {
@@ -23,9 +31,18 @@ resource stoacct 'Microsoft.Storage/storageAccounts@2019-04-01' = {
       keySource: 'Microsoft.Storage'
     }
     supportsHttpsTrafficOnly: true
+    allowSharedKeyAccess: false  // Disable key-based authentication, use Entra ID (managed identity) instead
+    networkAcls: enableNetworkIsolation ? {
+      defaultAction: 'Deny'
+      bypass: 'AzureServices'
+      virtualNetworkRules: virtualNetworkRules
+    } : {
+      defaultAction: 'Allow'
+    }
   }
 
   tags: tags
 }
 
 output stoacctOut string = stoacct.id
+output stoacctName string = stoacct.name

--- a/infrastructure/bicep/modules/vnet.bicep
+++ b/infrastructure/bicep/modules/vnet.bicep
@@ -1,0 +1,193 @@
+param baseName string
+param location string
+param tags object
+param vnetAddressPrefix string = '10.0.0.0/16'
+param defaultSubnetPrefix string = '10.0.0.0/24'
+param computeSubnetPrefix string = '10.0.1.0/24'
+param privateEndpointSubnetPrefix string = '10.0.2.0/24'
+
+// Network Security Group for the AML compute subnet. Azure Machine Learning
+// compute requires these service-tag rules to manage compute nodes inside a
+// VNet; without them, node provisioning fails.
+resource nsgCompute 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: 'nsg-training-${baseName}'
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowAzureMachineLearningInbound'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRanges: [ '44224' ]
+          sourceAddressPrefix: 'AzureMachineLearning'
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'AllowBatchNodeManagementInbound'
+        properties: {
+          priority: 110
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRanges: [ '29876-29877' ]
+          sourceAddressPrefix: 'BatchNodeManagement'
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'AllowStorageOutbound'
+        properties: {
+          priority: 100
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Storage'
+        }
+      }
+      {
+        name: 'AllowKeyVaultOutbound'
+        properties: {
+          priority: 110
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureKeyVault'
+        }
+      }
+      {
+        name: 'AllowAcrOutbound'
+        properties: {
+          priority: 120
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureContainerRegistry'
+        }
+      }
+      {
+        name: 'AllowAzureMachineLearningOutbound'
+        properties: {
+          priority: 130
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureMachineLearning'
+        }
+      }
+      {
+        name: 'AllowAzureActiveDirectoryOutbound'
+        properties: {
+          priority: 140
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureActiveDirectory'
+        }
+      }
+      {
+        name: 'AllowAzureResourceManagerOutbound'
+        properties: {
+          priority: 150
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureResourceManager'
+        }
+      }
+      {
+        name: 'AllowAzureMonitorOutbound'
+        properties: {
+          priority: 160
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureMonitor'
+        }
+      }
+    ]
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: 'vnet-${baseName}'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: 'default'
+        properties: {
+          addressPrefix: defaultSubnetPrefix
+          // Service endpoints are required for the VNet rules that storage,
+          // Key Vault, and ACR add to their network ACLs for these subnets.
+          serviceEndpoints: [
+            { service: 'Microsoft.Storage' }
+            { service: 'Microsoft.KeyVault' }
+            { service: 'Microsoft.ContainerRegistry' }
+          ]
+        }
+      }
+      {
+        name: 'aml-compute'
+        properties: {
+          addressPrefix: computeSubnetPrefix
+          networkSecurityGroup: {
+            id: nsgCompute.id
+          }
+          privateEndpointNetworkPolicies: 'Disabled'
+          serviceEndpoints: [
+            { service: 'Microsoft.Storage' }
+            { service: 'Microsoft.KeyVault' }
+            { service: 'Microsoft.ContainerRegistry' }
+          ]
+        }
+      }
+      {
+        name: 'private-endpoints'
+        properties: {
+          addressPrefix: privateEndpointSubnetPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+        }
+      }
+    ]
+  }
+  tags: tags
+}
+
+output vnetId string = vnet.id
+output vnetName string = vnet.name
+output defaultSubnetId string = vnet.properties.subnets[0].id
+output computeSubnetId string = vnet.properties.subnets[1].id
+output privateEndpointSubnetId string = vnet.properties.subnets[2].id

--- a/infrastructure/bicep/pipelines/bicep-ado-deploy-infra.yml
+++ b/infrastructure/bicep/pipelines/bicep-ado-deploy-infra.yml
@@ -54,6 +54,11 @@ stages:
                     enableMonitoring=$(enable_monitoring) \
                     enableContainerRegistry=$(enable_container_registry) \
                     enableComputeCluster=$(enable_aml_computecluster) \
+                    enableVNet=$(enable_vnet) \
+                    vnetAddressPrefix='$(vnet_address_prefix)' \
+                    defaultSubnetPrefix='$(default_subnet_prefix)' \
+                    computeSubnetPrefix='$(compute_subnet_prefix)' \
+                    peSubnetPrefix='$(pe_subnet_prefix)' \
                     tagCostCenter='$(tag_cost_center)' \
                     tagManagedBy='$(tag_managed_by)'
 
@@ -91,6 +96,11 @@ stages:
                           enableMonitoring=$(enable_monitoring) \
                           enableContainerRegistry=$(enable_container_registry) \
                           enableComputeCluster=$(enable_aml_computecluster) \
+                          enableVNet=$(enable_vnet) \
+                          vnetAddressPrefix='$(vnet_address_prefix)' \
+                          defaultSubnetPrefix='$(default_subnet_prefix)' \
+                          computeSubnetPrefix='$(compute_subnet_prefix)' \
+                          peSubnetPrefix='$(pe_subnet_prefix)' \
                           tagCostCenter='$(tag_cost_center)' \
                           tagManagedBy='$(tag_managed_by)'
 

--- a/infrastructure/bicep/pipelines/bicep-gha-deploy-infra.yml
+++ b/infrastructure/bicep/pipelines/bicep-gha-deploy-infra.yml
@@ -1,0 +1,284 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: Bicep - Deploy Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform (deploy or destroy)'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - destroy
+      wait_for_destroy:
+        description: 'Wait for resource group deletion to complete'
+        required: false
+        default: true
+        type: boolean
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/bicep/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/bicep/**'
+
+env:
+  config_env: "none"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  set-env-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      config-file: ${{ steps.set-output-defaults.outputs.config-file }}
+      environment: ${{ steps.set-output-defaults.outputs.environment }}
+    steps:
+      - id: set-prod-branch
+        name: set-prod-branch
+        if: ${{ github.ref == 'refs/heads/main'}}
+        run: |
+          echo "config_env=config-infra-prod.yml" >> $GITHUB_ENV
+          echo "env_name=prod" >> $GITHUB_ENV
+      - id: set-dev-branch
+        name: setdevbranch
+        if: ${{ github.ref != 'refs/heads/main'}}
+        run: |
+          echo "config_env=config-infra-dev.yml" >> $GITHUB_ENV
+          echo "env_name=dev" >> $GITHUB_ENV
+      - id: set-output-defaults
+        name: set-output-defaults
+        run: |
+          echo "config-file=$config_env" >> $GITHUB_OUTPUT
+          echo "environment=$env_name" >> $GITHUB_OUTPUT
+
+  get-config:
+    needs: set-env-branch
+    permissions:
+      contents: read
+    uses: Azure/mlops-templates/.github/workflows/read-yaml.yml@main
+    with:
+      file_name: ${{ needs.set-env-branch.outputs.config-file}}
+
+  lint:
+    name: Lint Bicep Code
+    needs: [get-config, set-env-branch]
+    runs-on: ubuntu-latest
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Bicep CLI
+        run: |
+          # Install Bicep CLI directly (no Azure login needed for linting)
+          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep /usr/local/bin/bicep
+          bicep --version
+
+      - name: Lint Bicep
+        run: |
+          bicep build $BICEP_DIR/$BICEP_FILE
+
+  validate:
+    name: Validate Bicep Deployment
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch, lint]
+    if: github.event_name != 'pull_request'
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    outputs:
+      sp_object_id: ${{ steps.get_sp_info.outputs.sp_object_id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Service Principal Object ID
+        id: get_sp_info
+        run: |
+          # Get the SP object ID from the client ID
+          SP_OBJECT_ID=$(az ad sp show --id ${{ secrets.AZURE_CLIENT_ID }} --query id -o tsv)
+          
+          echo "Service Principal Client ID: ${{ secrets.AZURE_CLIENT_ID }}"
+          echo "Service Principal Object ID: $SP_OBJECT_ID"
+          echo "sp_object_id=$SP_OBJECT_ID" >> $GITHUB_OUTPUT
+
+      - name: Generate Parameters File
+        run: |
+          cat > $BICEP_DIR/parameters.json << EOF
+          {
+            "\$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "prefix": { "value": "${{ needs.get-config.outputs.namespace }}" },
+              "postfix": { "value": "${{ needs.get-config.outputs.postfix }}" },
+              "env": { "value": "${{ needs.get-config.outputs.environment }}" },
+              "location": { "value": "${{ needs.get-config.outputs.location }}" },
+              "adoServicePrincipalId": { "value": "${{ steps.get_sp_info.outputs.sp_object_id }}" },
+              "amlComputeSku": { "value": "${{ needs.get-config.outputs.aml_compute_sku }}" },
+              "enableVNet": { "value": ${{ needs.get-config.outputs.enable_vnet }} },
+              "vnetAddressPrefix": { "value": "${{ needs.get-config.outputs.vnet_address_prefix }}" },
+              "defaultSubnetPrefix": { "value": "${{ needs.get-config.outputs.default_subnet_prefix }}" },
+              "computeSubnetPrefix": { "value": "${{ needs.get-config.outputs.compute_subnet_prefix }}" },
+              "peSubnetPrefix": { "value": "${{ needs.get-config.outputs.pe_subnet_prefix }}" },
+              "enableContainerRegistry": { "value": ${{ needs.get-config.outputs.enable_container_registry }} },
+              "tagCostCenter": { "value": "${{ needs.get-config.outputs.tag_cost_center }}" },
+              "tagManagedBy": { "value": "${{ needs.get-config.outputs.tag_managed_by }}" }
+            }
+          }
+          EOF
+          echo "Generated parameters.json:"
+          cat $BICEP_DIR/parameters.json
+
+      - name: Validate Bicep Deployment
+        run: |
+          az deployment sub validate \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --location ${{ needs.get-config.outputs.location }} \
+            --template-file $BICEP_DIR/$BICEP_FILE \
+            --parameters @$BICEP_DIR/parameters.json
+
+  deploy:
+    name: Deploy Infrastructure
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch, lint, validate]
+    if: github.event_name != 'pull_request' && github.event.inputs.action != 'destroy'
+    environment: ${{ needs.set-env-branch.outputs.environment }}
+    env:
+      BICEP_DIR: infrastructure/bicep
+      BICEP_FILE: main.bicep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Service Principal Object ID
+        id: get_sp_info
+        run: |
+          SP_OBJECT_ID=$(az ad sp show --id ${{ secrets.AZURE_CLIENT_ID }} --query id -o tsv)
+          
+          echo "Service Principal Client ID: ${{ secrets.AZURE_CLIENT_ID }}"
+          echo "Service Principal Object ID: $SP_OBJECT_ID"
+          echo "sp_object_id=$SP_OBJECT_ID" >> $GITHUB_OUTPUT
+
+      - name: Generate Parameters File
+        run: |
+          cat > $BICEP_DIR/parameters.json << EOF
+          {
+            "\$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "prefix": { "value": "${{ needs.get-config.outputs.namespace }}" },
+              "postfix": { "value": "${{ needs.get-config.outputs.postfix }}" },
+              "env": { "value": "${{ needs.get-config.outputs.environment }}" },
+              "location": { "value": "${{ needs.get-config.outputs.location }}" },
+              "adoServicePrincipalId": { "value": "${{ steps.get_sp_info.outputs.sp_object_id }}" },
+              "amlComputeSku": { "value": "${{ needs.get-config.outputs.aml_compute_sku }}" },
+              "enableVNet": { "value": ${{ needs.get-config.outputs.enable_vnet }} },
+              "vnetAddressPrefix": { "value": "${{ needs.get-config.outputs.vnet_address_prefix }}" },
+              "defaultSubnetPrefix": { "value": "${{ needs.get-config.outputs.default_subnet_prefix }}" },
+              "computeSubnetPrefix": { "value": "${{ needs.get-config.outputs.compute_subnet_prefix }}" },
+              "peSubnetPrefix": { "value": "${{ needs.get-config.outputs.pe_subnet_prefix }}" },
+              "enableContainerRegistry": { "value": ${{ needs.get-config.outputs.enable_container_registry }} },
+              "tagCostCenter": { "value": "${{ needs.get-config.outputs.tag_cost_center }}" },
+              "tagManagedBy": { "value": "${{ needs.get-config.outputs.tag_managed_by }}" }
+            }
+          }
+          EOF
+          echo "Generated parameters.json:"
+          cat $BICEP_DIR/parameters.json
+
+      - name: Deploy Bicep Template
+        run: |
+          echo "Deploying to ${{ needs.set-env-branch.outputs.environment }} environment..."
+          
+          az deployment sub create \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --location ${{ needs.get-config.outputs.location }} \
+            --template-file $BICEP_DIR/$BICEP_FILE \
+            --parameters @$BICEP_DIR/parameters.json
+
+      - name: Output Deployment Results
+        run: |
+          echo "Deployment completed successfully!"
+          az deployment sub show \
+            --name "bicep-gha-${{ github.run_number }}" \
+            --query properties.outputs
+
+  destroy:
+    name: Destroy Infrastructure
+    runs-on: ubuntu-latest
+    needs: [get-config, set-env-branch]
+    if: github.event.inputs.action == 'destroy'
+    environment: ${{ needs.set-env-branch.outputs.environment }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Delete Resource Group
+        run: |
+          echo "Destroying ${{ needs.set-env-branch.outputs.environment }} environment..."
+          
+          RG_NAME="rg-${{ needs.get-config.outputs.namespace }}-${{ needs.get-config.outputs.postfix }}${{ needs.get-config.outputs.environment }}"
+          MLW_NAME="mlw-${{ needs.get-config.outputs.namespace }}-${{ needs.get-config.outputs.postfix }}${{ needs.get-config.outputs.environment }}"
+          
+          echo "Deleting resource group: $RG_NAME"
+          
+          # Check if we should wait for deletion to complete
+          if [ "${{ github.event.inputs.wait_for_destroy }}" == "true" ]; then
+            echo "Waiting for resource group deletion to complete..."
+            az group delete --name $RG_NAME --yes
+            echo "Resource group $RG_NAME has been deleted!"
+            
+            # Purge soft-deleted ML Workspace
+            echo "Purging soft-deleted ML Workspace..."
+            az ml workspace delete --name $MLW_NAME --resource-group $RG_NAME --permanently-delete --yes 2>/dev/null || true
+            
+            # Purge any soft-deleted Key Vaults to allow redeployment
+            echo "Purging soft-deleted Key Vaults..."
+            DELETED_KVS=$(az keyvault list-deleted --query "[?contains(properties.vaultId, '$RG_NAME')].name" -o tsv 2>/dev/null || true)
+            for KV_NAME in $DELETED_KVS; do
+              echo "Purging Key Vault: $KV_NAME"
+              az keyvault purge --name $KV_NAME --location ${{ needs.get-config.outputs.location }} --no-wait || true
+            done
+            echo "Cleanup complete!"
+          else
+            az group delete --name $RG_NAME --yes --no-wait
+            echo "Resource group deletion initiated (async)!"
+          fi

--- a/infrastructure/bicep/pipelines/templates/kv-firewall-whitelist.yml
+++ b/infrastructure/bicep/pipelines/templates/kv-firewall-whitelist.yml
@@ -1,0 +1,51 @@
+# Key Vault Firewall Whitelist/Cleanup Pattern
+# Pre-step: Whitelist build agent IP on seeding KV
+# Post-step (always runs): Remove the IP rule
+# Usage: Include in pipeline stages that need to read secrets from a firewalled KV
+
+parameters:
+- name: keyVaultName
+  type: string
+- name: azureSubscription
+  type: string
+
+steps:
+  - task: AzureCLI@2
+    displayName: Whitelist build agent IP on Key Vault
+    name: whitelistAgentIp
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        AGENT_IP=$(curl -s https://api.ipify.org)
+        echo "Build agent public IP: $AGENT_IP"
+        echo "##vso[task.setvariable variable=agentIp;isOutput=true]$AGENT_IP"
+        
+        echo "Adding IP rule to Key Vault ${{ parameters.keyVaultName }}..."
+        az keyvault network-rule add \
+          --name ${{ parameters.keyVaultName }} \
+          --ip-address "$AGENT_IP/32" \
+          --only-show-errors || true
+        
+        # Wait for rule to propagate
+        sleep 10
+
+  - task: AzureCLI@2
+    displayName: Remove build agent IP from Key Vault
+    condition: always()
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        AGENT_IP=$(whitelistAgentIp.agentIp)
+        if [ -n "$AGENT_IP" ]; then
+          echo "Removing IP rule for $AGENT_IP from Key Vault ${{ parameters.keyVaultName }}..."
+          az keyvault network-rule remove \
+            --name ${{ parameters.keyVaultName }} \
+            --ip-address "$AGENT_IP/32" \
+            --only-show-errors || true
+        else
+          echo "No agent IP recorded, skipping cleanup"
+        fi

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -37,7 +37,7 @@ variable "github_actions_service_principal_id" {
 variable "enable_private_endpoints" {
   type        = bool
   description = "Enable private endpoints and VNet isolation for Azure ML workspace and dependent services"
-  default     = true  # Temporarily set to true for v1.2.0 testing
+  default     = false
 }
 
 variable "vnet_address_space" {


### PR DESCRIPTION
## Summary

Tier 2 of the phased enterprise-hardening initiative for the MLOps v2 project template. Adds VNet/private-endpoint networking, a phased Bicep deployment, and the user-assigned managed identity foundation required for identity-based datastore access. **All networking is feature-flagged off by default** (`enable_vnet: false`); existing dev/test deployments behave identically. Opt in via `config-infra-{dev,prod}.yml`.

Builds on Tier 1 (#150). This brings the Bicep path to parity with the Terraform path, which already ships private-endpoint networking and identity-based auth.

## Scope

### Networking (2.1) + phased deployment (2.2)
- New modules: `vnet.bicep`, `private_endpoint.bicep`, `private_dns_zones.bicep`
- `main.bicep` restructured into three phases:
  - **Phase 1** — resource group, managed identity, VNet
  - **Phase 2** — storage, Key Vault, ACR, App Insights, and private endpoints
  - **Phase 3** — AML workspace and compute
- Conditional private endpoints + private DNS zones for storage (blob + file), Key Vault, ACR, and the AML workspace when `enable_vnet` is true
- **NSG on the compute subnet** with the Azure ML service-tag rules (inbound `AzureMachineLearning:44224` + `BatchNodeManagement:29876-29877`; outbound to Storage/KeyVault/ACR/AML/AAD/ARM/Monitor) — required for AML compute to manage nodes inside the VNet
- Subnet service endpoints (`Microsoft.Storage`, `Microsoft.KeyVault`, `Microsoft.ContainerRegistry`) so the network-ACL VNet rules validate
- Network isolation: storage (`networkAcls` deny + `publicNetworkAccess: Disabled`), Key Vault, ACR (`Premium` + `publicNetworkAccess: Disabled`), and workspace (`publicNetworkAccess: Disabled`)
- Compute cluster and workspace injected into the compute subnet

### Identity foundation (prerequisite)
Key-based datastore auth does not work with the current AML workspace API, so the workspace must use a user-assigned managed identity for datastore access:
- New `managed_identity.bicep` (user-assigned identity)
- Workspace uses `UserAssigned` identity and `systemDatastoresAuthMode: 'identity'`; storage sets `allowSharedKeyAccess: false`
- Role assignments: workspace MSI gets Storage Blob Data Contributor, Storage Account Contributor, Key Vault Administrator, and AcrPull; optional ADO service-principal roles when `adoServicePrincipalId` is supplied

### Seeding Key Vault (2.3)
- New `seeding_keyvault.bicep` and `templates/kv-firewall-whitelist.yml` for temporarily whitelisting the build-agent IP on the Key Vault firewall

### Pipeline + config
- `bicep-ado-deploy-infra.yml` passes the new VNet parameters in both the validate and deploy stages
- VNet settings added to `config-infra-dev.yml` and `config-infra-prod.yml`

## Compatibility

- All networking defaults to off, so there are no breaking changes for existing deployments
- The workspace now uses a user-assigned identity with identity-based datastore auth (fixes key-based auth, which does not work on the current API)
- `amlComputeSku` defaults to `Standard_DS3_v2` (unchanged from the previous hard-coded value)

## Testing

- `az bicep build` on `main.bicep` is clean (0 errors; the two `BCP334` name-length warnings are pre-existing from Tier 1's `uniqueString`-derived names)
- `az deployment sub validate` passes for both `enableVNet=false` and `enableVNet=true`
- **Deployed end-to-end** on a real subscription with `enableVNet=true` — **32 resources** provisioned successfully (VNet + 3 subnets + NSG, 7 private DNS zones + links, storage/KV/ACR/App Insights, workspace, compute, and 6 private endpoints). Verified on the deployed resources:
  - storage `networkAcls.defaultAction=Deny`, `publicNetworkAccess=Disabled`, `allowSharedKeyAccess=false`
  - workspace `publicNetworkAccess=Disabled`
  - NSG created with the 9 AML service-tag rules and associated with the compute subnet

## Known limitation

The dev config default `enable_monitoring: false` leaves the workspace with `applicationInsights: null`, and the current AML workspace API rejects that (`Missing dependent resources in workspace json`). This is pre-existing behaviour from the Tier 1 monitoring flag, not introduced here — set `enable_monitoring: true` (or deploy Application Insights) when creating a workspace. Happy to address it in a separate change.

## Checklist

- [x] `az bicep build` clean
- [x] `az deployment sub validate` (both configs) + live deploy verified
- [x] Pipeline YAML wired for new parameters
- [x] No breaking changes (feature-flagged)
- [ ] Maintainer review
